### PR TITLE
ci: test Go 1.9.x, 1.10.x and tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: go
 go_import_path: gopkg.in/src-d/go-siva.v1
 
 go:
-  - 1.9
+  - 1.9.x
+  - 1.10.x
   - tip
 
 matrix:


### PR DESCRIPTION
More info:
https://github.com/src-d/guide/blob/master/engineering/conventions-go.md

Signed-off-by: Santiago M. Mola <santi@mola.io>