### PR TITLE
test: writing/reading an IndexEntry is not exactly idempotent

### DIFF
--- a/index_test.go
+++ b/index_test.go
@@ -52,7 +52,7 @@ func (s *IndexSuite) TestIndexEntryIdempotent(c *C) {
 	expected := &IndexEntry{}
 	expected.Name = "foo"
 	expected.Mode = 0644
-	expected.ModTime = time.Now()
+	expected.ModTime = time.Now().Local()
 	expected.Start = 84
 	expected.Size = 42
 	expected.CRC32 = 4242


### PR DESCRIPTION
Writing/reading an IndexEntry is not exactly idempotent, since we
do not store timezone/location for ModTime, deserialization will have
local time, which might differ from the input.

Example error:

```
----------------------------------------------------------------------
FAIL: index_test.go:47: IndexSuite.TestIndexEntryIdempotent

index_test.go:64:
    c.Assert(entry, DeepEquals, expected)
... obtained *siva.IndexEntry = &siva.IndexEntry{Header:siva.Header{Name:"foo", ModTime:time.Time{wall:0x2731e717, ext:63663979646, loc:(*time.Location)(0x6d8ae0)}, Mode:0x1a4, Flags:0x1}, Start:0x54, Size:0x2a, CRC32:0x1092, absStart:0x0}
... expected *siva.IndexEntry = &siva.IndexEntry{Header:siva.Header{Name:"foo", ModTime:time.Time{wall:0xbebe6f3fa731e717, ext:1210515, loc:(*time.Location)(0x6d8ae0)}, Mode:0x1a4, Flags:0x1}, Start:0x54, Size:0x2a, CRC32:0x1092, absStart:0x0}

OOPS: 27 passed, 1 FAILED
--- FAIL: Test (0.01s)
FAIL
FAIL	gopkg.in/src-d/go-siva.v1	0.015s
```

Signed-off-by: Santiago M. Mola <santi@mola.io>