### PR TITLE
Improve siva index generation in ReadWriter

### DIFF
--- a/readwriter.go
+++ b/readwriter.go
@@ -26,12 +26,17 @@ func NewReaderWriter(rw io.ReadWriteSeeker) (*ReadWriter, error) {
 	}
 
 	w := newWriter(rw)
+	w.oIndex = OrderedIndex(i.filter())
+	w.oIndex.Sort()
+
 	getIndexFunc := func() (Index, error) {
 		for _, e := range w.index {
 			e.absStart = uint64(end) + e.Start
 		}
-		return append(i, w.index...), nil
+
+		return Index(w.oIndex), nil
 	}
+
 	r := newReaderWithIndex(rw, getIndexFunc)
 	return &ReadWriter{r, w}, nil
 }

--- a/readwriter_test.go
+++ b/readwriter_test.go
@@ -67,7 +67,15 @@ func (s *ReadWriterSuite) testWriteRead(c *C, f *os.File, iter int) {
 
 		index, err := rw.Index()
 		c.Assert(err, IsNil)
-		c.Assert(len(index), Equals, iters*iter+i+1)
+
+		// index after the first iteration will contain the total amount
+		// of files
+		num := i + 1
+		if iter > 0 {
+			num = iters
+		}
+
+		c.Assert(len(index), Equals, num)
 
 		e := index.Find(curName)
 		c.Assert(e, NotNil)
@@ -171,4 +179,58 @@ func (_ dummyReadWriterSeeker) Write(p []byte) (n int, err error) {
 
 func (_ dummyReadWriterSeeker) Seek(offset int64, whence int) (n int64, err error) {
 	return
+}
+
+func (s *ReadWriterSuite) TestDelete(c *C) {
+	data := "data"
+
+	path := filepath.Join(s.tmpDir, c.TestName())
+	tmpFile, err := os.Create(path)
+	c.Assert(err, IsNil)
+	c.Assert(tmpFile, NotNil)
+
+	rw, err := siva.NewReaderWriter(tmpFile)
+	c.Assert(err, IsNil)
+
+	testSteps := []struct {
+		name  string
+		del   bool
+		files []string
+	}{
+		{"one", false, []string{"one"}},
+		{"two", false, []string{"one", "two"}},
+		{"three", false, []string{"one", "three", "two"}},
+		{"two", true, []string{"one", "three"}},
+		{"two", false, []string{"one", "three", "two"}},
+		{"four", true, []string{"one", "three", "two"}},
+		{"three", true, []string{"one", "two"}},
+	}
+
+	for _, t := range testSteps {
+		var flags siva.Flag
+		if t.del {
+			flags = siva.FlagDeleted
+		}
+
+		err := rw.WriteHeader(&siva.Header{
+			Name:  t.name,
+			Flags: flags,
+		})
+		c.Assert(err, IsNil)
+
+		written, err := rw.Write([]byte(data))
+		c.Assert(err, IsNil)
+		c.Assert(written, Equals, len(data))
+
+		err = rw.Flush()
+		c.Assert(err, IsNil)
+
+		index, err := rw.Index()
+		c.Assert(err, IsNil)
+
+		c.Assert(len(index), Equals, len(t.files))
+		for i, name := range t.files {
+			c.Assert(index[i].Name, Equals, name)
+		}
+	}
 }

--- a/writer.go
+++ b/writer.go
@@ -21,6 +21,7 @@ type Writer interface {
 type writer struct {
 	w        *hashedWriter
 	index    Index
+	oIndex   OrderedIndex
 	current  *IndexEntry
 	position uint64
 	closed   bool
@@ -49,6 +50,8 @@ func (w *writer) WriteHeader(h *Header) error {
 	}
 
 	w.index = append(w.index, w.current)
+	w.oIndex = w.oIndex.Update(w.current)
+
 	return nil
 }
 


### PR DESCRIPTION
When using a `ReadWriter` the index in regenerated each time `Index` is called. These are the steps to generate one usable index:

* Create new index merging index from file and current changes
* Remove duplicates
* Sort index by position

Also, to find a file in the index it is walked until a match is found. This needs to be done each time a file has to be opened.

For small number of files this is OK but when a repo has a lot or references the time spent here can be a lot.

Now there's a new index type called `OrderedIndex` that stores the `IndexEntries` in lexicographic order. This allows to do binary searches for faster file location and also makes possible update the index
instead of regenerating it each time.