### PR TITLE
Clarify that flags are bitwise, and that FlagDeleted is non-zero.

### DIFF
--- a/common.go
+++ b/common.go
@@ -8,13 +8,12 @@ import (
 	"time"
 )
 
+// Flag carries a bitwise OR of flag values affecting an archive entry.
 type Flag uint32
 
 const (
-	_ Flag = iota // we discard the 0
-
-	//FlagDeleted should be used to identify when a file is deleted
-	FlagDeleted Flag = iota
+	// FlagDeleted is set to indicate when a file is deleted.
+	FlagDeleted Flag = 1 << iota
 )
 
 // Header contains the meta information from a file


### PR DESCRIPTION
This commit has no functional change, it only clarifies the documentation of
header flags. Specifically:

- Add a missing doc comment to the exported Flag type declaration.

- Consolidate the declaration of FlagDeleted so it is more obvious to the
  reader in godoc that it is non-zero. This also ensures that if we add more
  enumerators later, they will shift correctly.
