### PR TITLE
Do not permit index entries to be flushed twice.

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -74,28 +74,23 @@ func (w *writer) Write(b []byte) (int, error) {
 func (w *writer) Flush() error {
 	if w.closed {
 		return ErrClosedWriter
-	}
-
-	if w.current == nil {
+	} else if w.current == nil {
 		return ErrMissingHeader
 	}
 
 	w.current.Size = w.position - w.current.Start
 	w.current.CRC32 = w.w.Checksum()
+	w.current = nil
 	w.w.Reset()
-
 	return nil
 }
 
 func (w *writer) flushIfPending() error {
 	if w.closed {
 		return ErrClosedWriter
-	}
-
-	if w.current == nil {
+	} else if w.current == nil {
 		return nil
 	}
-
 	return w.Flush()
 }
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -46,6 +46,23 @@ func (s *WriterSuite) TestFlushOnClose(c *C) {
 	c.Assert(err, Equals, ErrClosedWriter)
 }
 
+func (s *WriterSuite) TestDoubleFlushRegression(c *C) {
+	buf := new(bytes.Buffer)
+	w := NewWriter(buf)
+	const data = "foo"
+	c.Assert(w.WriteHeader(&Header{
+		Name: "test.txt",
+		Mode: 0640,
+	}), IsNil)
+	_, err := w.Write([]byte(data))
+	c.Assert(err, IsNil)
+	c.Assert(w.Flush(), IsNil)
+	want := *w.(*writer).index[0]
+	c.Assert(w.Close(), IsNil)
+	got := *w.(*writer).index[0]
+	c.Assert(got, Equals, want)
+}
+
 func (s *WriterSuite) TestWriterReaderIdempotent(c *C) {
 	buf := new(bytes.Buffer)
 	w := NewWriter(buf)


### PR DESCRIPTION
Fixes #45. When a Flush succeeds for an index entry, drop the current entry
after updating its fields. This ensures a subsequent flush check will not
overwrite its fields with the clobbered state of the CRC context.

Signed-off-by: M. J. Fromberger <michael.j.fromberger@gmail.com>